### PR TITLE
Expose markdown-it options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A version of marky-markdown that does less.
 
 This little module converts markdown to HTML with [markdown-it](https://github.com/markdown-it/markdown-it) (a fast and CommonMark compliant parser), then parses that HTML into a queryable DOM object using [cheerio](https://github.com/cheeriojs/cheerio).
 
-This module is inspired by [marky-markdown](https://github.com/npm/marky-markdown), and has a very similar API. It does less, but has a much smaller dependency footprint because it doesn't rely on any native C++ modules. If you need syntax highlighting, sanitized HTML, short emoji support, etc, use marky-markdown.
+This module is inspired by [marky-markdown](https://github.com/npm/marky-markdown), and has a very similar API. It does less, but has a much smaller dependency footprint because it doesn't rely on any native C++ modules. If you need syntax highlighting, sanitized HTML, short emoji support, etc, use underlying `markdown-it` [options](https://markdown-it.github.io/markdown-it/), see below.
 
 ## Installation
 
@@ -36,6 +36,18 @@ var $ = marky('some/markdown/file.md')
 npm install
 npm test
 ```
+
+## markdown-it options example
+
+```js
+var opts = {
+  html: true
+}
+
+var $ = marky('- Some list item <a href="item.html">item</a>', opts)
+
+```
+For all `markdown-it` [options](https://markdown-it.github.io/markdown-it/).
 
 ## Dependencies
 

--- a/index.js
+++ b/index.js
@@ -2,10 +2,12 @@ const path = require('path')
 const fs = require('fs')
 const isFile = require('is-file')
 const cheerio = require('cheerio')
-const markdown = require('markdown-it')()
-  .use(require('markdown-it-named-headers'))
+const md = require('markdown-it')
 
-module.exports = function marky (input) {
+module.exports = function marky (input, opts = {}) {
+  const markdown = md(opts)
+    .use(require('markdown-it-named-headers'))
+
   if (isFile(input)) {
     input = fs.readFileSync(input, 'utf8')
   }


### PR DESCRIPTION
Fix #1 

This PR also opens the possibility to use `highlight.js` as mentioned in `markdown-it` [docs](https://markdown-it.github.io/markdown-it/)

Like this:
```
var opts = {
          highlight: function (str, lang) {
            if (lang && hljs.getLanguage(lang)) {
              try {
                return '<pre class="hljs"><code>' +
                       hljs.highlight(lang, str, true).value +
                       '</code></pre>';
              } catch (__) {}
            }

            return '<pre class="hljs"><code>' + md.utils.escapeHtml(str) + '</code></pre>';
          }
}
```