### PR TITLE
Add access to underlying markdown-it options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="1.3.0"></a>
+# 1.3.0 (2017-05-03)
+
+* add access to underlying markdown-it options ([c52d7c3](https://github.com/zeke/marky-markdown-lite/commit/c52d7c3))
+
+
+
 <a name="1.2.0"></a>
 # 1.2.0 (2016-07-27)
 
@@ -21,6 +28,3 @@
 * one point oh ([9746806](https://github.com/zeke/marky-markdown-lite/commit/9746806))
 * readme touch-ups ([2e222bb](https://github.com/zeke/marky-markdown-lite/commit/2e222bb))
 * single quotes ([8e374d5](https://github.com/zeke/marky-markdown-lite/commit/8e374d5))
-
-
-

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A version of marky-markdown that does less.
 
 This little module converts markdown to HTML with [markdown-it](https://github.com/markdown-it/markdown-it) (a fast and CommonMark compliant parser), then parses that HTML into a queryable DOM object using [cheerio](https://github.com/cheeriojs/cheerio).
 
-This module is inspired by [marky-markdown](https://github.com/npm/marky-markdown), and has a very similar API. It does less, but has a much smaller dependency footprint because it doesn't rely on any native C++ modules. If you need syntax highlighting, sanitized HTML, short emoji support, etc, use marky-markdown.
+This module is inspired by [marky-markdown](https://github.com/npm/marky-markdown), and has a very similar API. It does less, but has a much smaller dependency footprint because it doesn't rely on any native C++ modules. If you need syntax highlighting, sanitized HTML, short emoji support, etc, use underlying `markdown-it` [options](https://markdown-it.github.io/markdown-it/#MarkdownIt.new), see **Options** below.
 
 ## Installation
 
@@ -35,6 +35,29 @@ var $ = marky('some/markdown/file.md')
 ```sh
 npm install
 npm test
+```
+
+## Options
+
+You can use all the `markdown-it` [options](https://markdown-it.github.io/markdown-it/#MarkdownIt.new).
+
+#### syntax
+
+`marky ( input [, options] )`
+
+- **input** (String) - Source string (could be also a path to a markdown file)
+- **options** (Object) - `markdown-it` options
+
+##### Accept HTML example
+
+```js
+var opts = {
+  html: true
+}
+
+var $ = marky('- Some list item <a href="item.html">here</a>', opts)
+
+console.log( $('ul li a').attr('href') ) // Outputs: 'item.html'
 ```
 
 ## Dependencies

--- a/index.js
+++ b/index.js
@@ -2,14 +2,16 @@ const path = require('path')
 const fs = require('fs')
 const isFile = require('is-file')
 const cheerio = require('cheerio')
-const markdown = require('markdown-it')()
-  .use(require('markdown-it-named-headers'))
+const markdown = require('markdown-it')
 
-module.exports = function marky (input) {
+module.exports = function marky (input, opts = {}) {
+  const md = markdown(opts)
+    .use(require('markdown-it-named-headers'))
+
   if (isFile(input)) {
     input = fs.readFileSync(input, 'utf8')
   }
-  const $ = cheerio.load(markdown.render(input))
+  const $ = cheerio.load(md.render(input))
 
   $('h1,h2,h3,h4,h5,h6').each(function (i, el) {
     $(el).attr('title', $(el).text())

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marky-markdown-lite",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A version of marky-markdown that does less",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -5,6 +5,7 @@ const marky = require('./')
 
 const fixturePath = path.join(__dirname, 'fixture.md')
 const sampleMarkdown = fs.readFileSync(fixturePath, 'utf8')
+const markdownWithHTML = `- Some list item <a href="item.html">here</a>`
 
 tape('marky-markdown-lite', function(t){
   t.equal(typeof marky, 'function', 'is a function')
@@ -18,6 +19,12 @@ tape('marky-markdown-lite', function(t){
   t.equal($('h1').attr('title'), 'I am a heading', 'sets heading titles to their textContent')
 
   t.equal($('h1').attr('id'), 'i-am-a-heading', 'adds slugified DOM ids to heading elements')
+
+  t.comment('Accepts an object with markdown-it options like `{html:true}`')
+  var $ = marky(markdownWithHTML, {html:true})
+  t.equal($('ul li').text(), 'Some list item here', 'enable HTML tags in source (by not escaping them)')
+
+  t.equal($('ul li a').attr('href'), 'item.html', 'let access to attributes in HTML tags')
 
   t.end()
 })


### PR DESCRIPTION
Fix #1 

- Adds capability to use `markdown-it` options (without breaking anything)
- Added options usage example on README
- Added a couple of test

![marky-markdown-lite_test_ok](https://cloud.githubusercontent.com/assets/4935817/25647994/be3729b4-2f8c-11e7-9895-c188459fdbc7.png)

---
As a side note, I had a rough time dealing with `conventional-changelog`

I followed the recommended workflow

1. Make changes
2. Commit those changes
3. Make sure Travis turns green
4. Bump version in `package.json`
5. `conventionalChangelog` (by running `npm test` with "conventional-changelog -i CHANGELOG.md -s -r 0" as included in the `package.json` scripts)
6. Commit `package.json` and `CHANGELOG.md` files
7. Tag
8. Push

...but results were not satisfactory so I ended editing `CHANGELOG.md` to suit.

If you want me to change anything or redo it, just let me know