### PR TITLE
Access to underlying markdown-it options with Node 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "4"
+script: node test.js | tap-spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="1.3.0"></a>
+# 1.3.0 (2017-05-03)
+
+* add access to underlying markdown-it options ([c52d7c3](https://github.com/zeke/marky-markdown-lite/commit/c52d7c3))
+
+
+
 <a name="1.2.0"></a>
 # 1.2.0 (2016-07-27)
 
@@ -21,6 +28,3 @@
 * one point oh ([9746806](https://github.com/zeke/marky-markdown-lite/commit/9746806))
 * readme touch-ups ([2e222bb](https://github.com/zeke/marky-markdown-lite/commit/2e222bb))
 * single quotes ([8e374d5](https://github.com/zeke/marky-markdown-lite/commit/8e374d5))
-
-
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,19 @@
+<a name="1.3.1"></a>
+## 1.3.1 (2017-05-04)
+
+* 1.3.1 ([fdb1da0](https://github.com/zeke/marky-markdown-lite/commit/fdb1da0))
+* add Travis CI for Node 4 support test ([76f1dd2](https://github.com/zeke/marky-markdown-lite/commit/76f1dd2))
+* Correct default parameter to be Node 4 compatible ([64ad3c1](https://github.com/zeke/marky-markdown-lite/commit/64ad3c1))
+
+
+
 <a name="1.3.0"></a>
 # 1.3.0 (2017-05-03)
 
-* add access to underlying markdown-it options ([c52d7c3](https://github.com/zeke/marky-markdown-lite/commit/c52d7c3))
-
-
-
-<a name="1.2.0"></a>
-# 1.2.0 (2016-07-27)
-
+* 1.2.0 ([c9cb9ec](https://github.com/zeke/marky-markdown-lite/commit/c9cb9ec))
+* 1.3.0 ([5fbfa49](https://github.com/zeke/marky-markdown-lite/commit/5fbfa49))
 * add a changelog ([1e64c03](https://github.com/zeke/marky-markdown-lite/commit/1e64c03))
+* add access to underlying markdown-it options ([c52d7c3](https://github.com/zeke/marky-markdown-lite/commit/c52d7c3))
 * store textContent of all heading tags in title attributes so they can be accessed using CSS selector ([1e1481e](https://github.com/zeke/marky-markdown-lite/commit/1e1481e))
 
 
@@ -28,3 +33,6 @@
 * one point oh ([9746806](https://github.com/zeke/marky-markdown-lite/commit/9746806))
 * readme touch-ups ([2e222bb](https://github.com/zeke/marky-markdown-lite/commit/2e222bb))
 * single quotes ([8e374d5](https://github.com/zeke/marky-markdown-lite/commit/8e374d5))
+
+
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A version of marky-markdown that does less.
 
 This little module converts markdown to HTML with [markdown-it](https://github.com/markdown-it/markdown-it) (a fast and CommonMark compliant parser), then parses that HTML into a queryable DOM object using [cheerio](https://github.com/cheeriojs/cheerio).
 
-This module is inspired by [marky-markdown](https://github.com/npm/marky-markdown), and has a very similar API. It does less, but has a much smaller dependency footprint because it doesn't rely on any native C++ modules. If you need syntax highlighting, sanitized HTML, short emoji support, etc, use marky-markdown.
+This module is inspired by [marky-markdown](https://github.com/npm/marky-markdown), and has a very similar API. It does less, but has a much smaller dependency footprint because it doesn't rely on any native C++ modules. If you need syntax highlighting, sanitized HTML, short emoji support, etc, use underlying `markdown-it` [options](https://markdown-it.github.io/markdown-it/#MarkdownIt.new), see **Options** below.
 
 ## Installation
 
@@ -35,6 +35,29 @@ var $ = marky('some/markdown/file.md')
 ```sh
 npm install
 npm test
+```
+
+## Options
+
+You can use all the `markdown-it` [options](https://markdown-it.github.io/markdown-it/#MarkdownIt.new).
+
+#### syntax
+
+`marky ( input [, options] )`
+
+- **input** (String) - Source string (could be also a path to a markdown file)
+- **options** (Object) - `markdown-it` options
+
+##### Accept HTML example
+
+```js
+var opts = {
+  html: true
+}
+
+var $ = marky('- Some list item <a href="item.html">here</a>', opts)
+
+console.log( $('ul li a').attr('href') ) // Outputs: 'item.html'
 ```
 
 ## Dependencies

--- a/index.js
+++ b/index.js
@@ -2,14 +2,16 @@ const path = require('path')
 const fs = require('fs')
 const isFile = require('is-file')
 const cheerio = require('cheerio')
-const markdown = require('markdown-it')()
-  .use(require('markdown-it-named-headers'))
+const markdown = require('markdown-it')
 
-module.exports = function marky (input) {
+module.exports = function marky (input, opts = {}) {
+  const md = markdown(opts)
+    .use(require('markdown-it-named-headers'))
+
   if (isFile(input)) {
     input = fs.readFileSync(input, 'utf8')
   }
-  const $ = cheerio.load(markdown.render(input))
+  const $ = cheerio.load(md.render(input))
 
   $('h1,h2,h3,h4,h5,h6').each(function (i, el) {
     $(el).attr('title', $(el).text())

--- a/index.js
+++ b/index.js
@@ -4,7 +4,9 @@ const isFile = require('is-file')
 const cheerio = require('cheerio')
 const markdown = require('markdown-it')
 
-module.exports = function marky (input, opts = {}) {
+module.exports = function marky (input, opts) {
+  opts = (typeof opts !== 'undefined') ?  opts : {}
+  
   const md = markdown(opts)
     .use(require('markdown-it-named-headers'))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marky-markdown-lite",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A version of marky-markdown that does less",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marky-markdown-lite",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A version of marky-markdown that does less",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -5,6 +5,7 @@ const marky = require('./')
 
 const fixturePath = path.join(__dirname, 'fixture.md')
 const sampleMarkdown = fs.readFileSync(fixturePath, 'utf8')
+const markdownWithHTML = `- Some list item <a href="item.html">here</a>`
 
 tape('marky-markdown-lite', function(t){
   t.equal(typeof marky, 'function', 'is a function')
@@ -18,6 +19,12 @@ tape('marky-markdown-lite', function(t){
   t.equal($('h1').attr('title'), 'I am a heading', 'sets heading titles to their textContent')
 
   t.equal($('h1').attr('id'), 'i-am-a-heading', 'adds slugified DOM ids to heading elements')
+
+  t.comment('Accepts an object with markdown-it options like `{html:true}`')
+  var $ = marky(markdownWithHTML, {html:true})
+  t.equal($('ul li').text(), 'Some list item here', 'enable HTML tags in source (by not escaping them)')
+
+  t.equal($('ul li a').attr('href'), 'item.html', 'let access to attributes in HTML tags')
 
   t.end()
 })


### PR DESCRIPTION
Fixed!

![travis-ok-marky-markdown-lite](https://cloud.githubusercontent.com/assets/4935817/25692931/bedebbfe-306b-11e7-8492-c31310cbf059.png)

- Change default parameter to be Node 4 compatible
- Added `.travis.yml` to check Node 4 support

I think I got `conventional-changelog` figured out (this time I did not do any `CHANGELOG.md` manual editing at all).

Steps are:
1. Make changes
2. Commit those changes
3. Run only `node test.js` (do not run `npm test` yet)
4. Bump version in `package.json`
5. Commit bump with only version number message
6. Run `npm test`
7. Commit `CHANGELOG.md` file with "update changelog to \<version-number>"
8. Tag
9. Push with --follow-tags

This way, `CHANGELOG.md` will include the version bump as part of the same bump and ONLY the "update changelog to \<version-number>" message will appear on the future version bump.

IMHO, this is better workflow that does not need `CHANGELOG.md` file manual editing and looks nice.